### PR TITLE
performance tuning opentelemetry-php config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,7 @@ x-otel-common:
   OTEL_TRACES_EXPORTER: otlp
   OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: http/protobuf
   OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://jaeger:4318/v1/traces
-  OTEL_PHP_TRACES_PROCESSOR: simple
-
-version: "3.8"
+  OTEL_PHP_TRACES_PROCESSOR: batch
 
 services:
 

--- a/docker/compose/php-fpm/Dockerfile
+++ b/docker/compose/php-fpm/Dockerfile
@@ -6,7 +6,8 @@ USER root
 
 RUN apk --update --no-cache add \
      php8.3-opentelemetry \
-     php8.3-grpc
+     php8.3-grpc \
+     php8.3-protobuf
 
 USER skpr
 


### PR DESCRIPTION
- use batch instead of simple span processor (one export, instead of one export per span)
- install ext-protobuf (native protobuf package is awful, performance-wise)